### PR TITLE
fix run name when kind is trec

### DIFF
--- a/ranx/run.py
+++ b/ranx/run.py
@@ -245,7 +245,7 @@ class Run(object):
 
         run = Run.from_dict(run)
 
-        if type == "trec":
+        if kind == "trec":
             run.name = name
 
         return run

--- a/tests/unit/ranx/run_test.py
+++ b/tests/unit/ranx/run_test.py
@@ -198,6 +198,7 @@ def test_from_trec_file():
     assert run.run["q1"]["d3"] == 0.3
     assert run.run["q2"]["d1"] == 0.1
     assert run.run["q2"]["d2"] == 0.2
+    assert run.name == "example"
 
 
 def test_from_json_file():


### PR DESCRIPTION
Hi,

Run names were not properly saved when loading trec runs from file. It was not covered in the tests.

Best,

Maxime.
