### PR TITLE
fix: report: metric_labels: latex does not like underscores

### DIFF
--- a/ranx/data_structures/report.py
+++ b/ranx/data_structures/report.py
@@ -13,7 +13,7 @@ super_chars = list("ᵃᵇᶜᵈᵉᶠᵍʰᶦʲᵏˡᵐⁿᵒᵖ۹ʳˢᵗᵘᵛ
 
 metric_labels = {
     "hits": "Hits",
-    "hit_rate": "Hit_Rate",
+    "hit_rate": "Hit Rate",
     "precision": "P",
     "recall": "Recall",
     "f1": "F1",
@@ -21,7 +21,7 @@ metric_labels = {
     "mrr": "MRR",
     "map": "MAP",
     "ndcg": "NDCG",
-    "ndcg_burges": "NDCG_Burges",
+    "ndcg_burges": "NDCG Burges",
 }
 
 stat_test_labels = {


### PR DESCRIPTION
Hi, this is a ridiculously small PR but it had to be done at some point :)

(In case you don’t get it: underscores are ugly and they should have been escaped anyway to print in latex)