### PR TITLE
Fix typo of the DCG-Burges formula in metrics.md

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -181,7 +181,7 @@ Compute **Discounted Cumulative Gain** (DCG) at k as proposed by [Burges et al.]
 </details>
 
 $$
-\operatorname{DCG} = \frac{2^{\operatorname{rel}_i-1}}{\log_2(i+1)}
+\operatorname{DCG} = \frac{2^{\operatorname{rel}_i}-1}{\log_2(i+1)}
 $$
 
 where,


### PR DESCRIPTION
This PR just fixes a typo of the DCG-Burges formula in metrics.md.

A newline at the end of the file has also been added automatically by the GitHub editor, following [the POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).