### PR TITLE
Fix superscript letter i in compare report

### DIFF
--- a/ranx/data_structures/report.py
+++ b/ranx/data_structures/report.py
@@ -9,7 +9,7 @@ from tabulate import tabulate
 from .frozenset_dict import FrozensetDict
 
 chars = list("abcdefghijklmnopqrstuvwxyz")
-super_chars = list("ᵃᵇᶜᵈᵉᶠᵍʰᶦʲᵏˡᵐⁿᵒᵖ۹ʳˢᵗᵘᵛʷˣʸᶻ")
+super_chars = list("ᵃᵇᶜᵈᵉᶠᵍʰⁱʲᵏˡᵐⁿᵒᵖ۹ʳˢᵗᵘᵛʷˣʸᶻ")
 
 metric_labels = {
     **{


### PR DESCRIPTION
The superscript letter i used to be a [capital letter](https://symbl.cc/en/1DA6/) which looks very much like the small letter r. I replaced it by a [small superscript i](https://symbl.cc/en/2071/).

See the following example which demonstrates how it looks with the current master:
![image](https://github.com/user-attachments/assets/cf2a555b-69bb-46c5-bc26-89396dd27b92)
The superscripts actually refer to the runs **e, i, j** but it looks like **e, r, j** to me because I don't expect a capital letter there.