### PR TITLE
Fixed few typos in the documentation

### DIFF
--- a/docs/fusion.md
+++ b/docs/fusion.md
@@ -335,7 +335,7 @@ Computes Log_ISR as proposed by [Mourão et al.](https://www.sciencedirect.com/s
 
 
 ### LogN_ISR
-Computes Log_ISR as proposed by [Mourão et al.](https://www.sciencedirect.com/science/article/abs/pii/S0895611114000664).
+Computes LogN_ISR as proposed by [Mourão et al.](https://www.sciencedirect.com/science/article/abs/pii/S0895611114000664).
 <details>
     <summary>BibTeX</summary>
     ```bibtex

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Any dependence on `trec_eval` have been removed to make `ranx` truly MIT-complia
 It offers a user-friendly interface to evaluate and compare [Information Retrieval](https://en.wikipedia.org/wiki/Information_retrieval) and [Recommender Systems](https://en.wikipedia.org/wiki/Recommender_system).
 [ranx](https://github.com/AmenRa/ranx) allows you to perform statistical tests and export [LaTeX](https://en.wikipedia.org/wiki/LaTeX) tables for your scientific publications.
 Moreover, [ranx](https://github.com/AmenRa/ranx) provides several [fusion algorithms](https://amenra.github.io/ranx/fusion) and [normalization strategies](https://amenra.github.io/ranx/normalization), and an automatic [fusion optimization](https://amenra.github.io/ranx/fusion/#optimize-fusion) functionality.
-[ranx](https://github.com/AmenRa/ranx) also have a companion repository of pre-computed runs to facilitated model comparisons called [ranxhub](https://amenra.github.io/ranxhub).
+[ranx](https://github.com/AmenRa/ranx) also have a companion repository of pre-computed runs to facilitate model comparisons called [ranxhub](https://amenra.github.io/ranxhub).
 On [ranxhub](https://amenra.github.io/ranxhub), you can download and share pre-computed runs for Information Retrieval datasets, such as [MSMARCO Passage Ranking](https://arxiv.org/abs/1611.09268).
 [ranx](https://github.com/AmenRa/ranx) was featured in [ECIR 2022](https://ecir2022.org), [CIKM 2022](https://www.cikm2022.org), and [SIGIR 2023](https://sigir.org/sigir2023). 
  
@@ -91,7 +91,7 @@ A full list of the available runs is provided [here](https://amenra.github.io/ra
 | [CombMED](https://amenra.github.io/ranx/fusion/#combmed) | [CombGMNZ](https://amenra.github.io/ranx/fusion/#combgmnz) | [RBC](https://amenra.github.io/ranx/fusion/#rank-biased-centroids-rbc)  | [PosFuse](https://amenra.github.io/ranx/fusion/#posfuse)     | [Weighted BordaFuse](https://amenra.github.io/ranx/fusion/#weighted-bordafuse) |
 | [CombANZ](https://amenra.github.io/ranx/fusion/#combanz) | [ISR](https://amenra.github.io/ranx/fusion/#isr)           | [WMNZ](https://amenra.github.io/ranx/fusion/#wmnz)                      | [ProbFuse](https://amenra.github.io/ranx/fusion/#probfuse)   | [Condorcet](https://amenra.github.io/ranx/fusion/#condorcet)                   |
 | [CombMAX](https://amenra.github.io/ranx/fusion/#combmax) | [Log_ISR](https://amenra.github.io/ranx/fusion/#log_isr)   | [Mixed](https://amenra.github.io/ranx/fusion/#mixed)                    | [SegFuse](https://amenra.github.io/ranx/fusion/#segfuse)     | [Weighted Condorcet](https://amenra.github.io/ranx/fusion/#weighted-condorcet) |
-| [CombSUM](https://amenra.github.io/ranx/fusion/#combsum) | [LogN_ISR](https://amenra.github.io/ranx/fusion/#logn_isr) | [BayesFuse](https://amenra.github.io/ranx/fusion/#bayesfuse)            | [SlideFuse](https://amenra.github.io/ranx/fusion/#slidefuse) | [Weighted Sum](https://amenra.github.io/ranx/fusion/#wighted-sum)              |
+| [CombSUM](https://amenra.github.io/ranx/fusion/#combsum) | [LogN_ISR](https://amenra.github.io/ranx/fusion/#logn_isr) | [BayesFuse](https://amenra.github.io/ranx/fusion/#bayesfuse)            | [SlideFuse](https://amenra.github.io/ranx/fusion/#slidefuse) | [Weighted Sum](https://amenra.github.io/ranx/fusion/#weighted-sum)              |
 
 Please, refer to the [documentation](https://amenra.github.io/ranx/fusion) for further details.
 

--- a/docs/qrels.md
+++ b/docs/qrels.md
@@ -79,7 +79,7 @@ qrels = Qrels.from_parquet(
 
 ## Save
 Write `qrels` to `path` as JSON file or TREC qrels format.  
-File type is automatically inferred form the filename extension: `.json` -> `json`, `.trec` -> `trec`, `.txt` -> `trec`, `.parq` -> `parquet`, `.parquet` -> `parquet`.  
+File type is automatically inferred from the filename extension: `.json` -> `json`, `.trec` -> `trec`, `.txt` -> `trec`, `.parq` -> `parquet`, `.parquet` -> `parquet`.  
 Use the `kind` argument to override the default behavior.
 
 ```python

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,7 +1,7 @@
 # Report
 
 A `Report` instance is automatically generated as the results of a comparison.  
-A `Report` provides a convenient way of inspecting a comparison results and exporting those il LaTeX for your scientific publications.  
+A `Report` provides a convenient way of inspecting a comparison results and exporting those in LaTeX for your scientific publications.  
 By changing the values of the parameters `rounding_digits` (int) and `show_percentages` (bool) you can control what is shown on printing and when generating LaTeX tables.
 
 ```python

--- a/docs/run.md
+++ b/docs/run.md
@@ -80,7 +80,7 @@ run = Run.from_parquet(
 
 ## Save
 Write `run` to `path` as JSON file, TREC run, LZ4 file, or Parquet file.   
-File type is automatically inferred form the filename extension: `.json` -> `json`, `.trec` -> `trec`, `.txt` -> `trec`, and `.lz4` -> `lz4`, `.parq` -> `parquet`, `.parquet` -> `parquet`.  
+File type is automatically inferred from the filename extension: `.json` -> `json`, `.trec` -> `trec`, `.txt` -> `trec`, and `.lz4` -> `lz4`, `.parq` -> `parquet`, `.parquet` -> `parquet`.  
 Use the `kind` argument to override this behavior.
 
 ```python


### PR DESCRIPTION
While reading the [Run](https://amenra.github.io/ranx/run/) and [Qrels](https://amenra.github.io/ranx/qrels/#save) pages, I found the same typo in the save section that I fixed.

**Before**
```text
File type is automatically inferred `form` the filename extension ...
```

**After**
```text
File type is automatically inferred `from` the filename extension ...
```

I found another typo in the [Report](https://amenra.github.io/ranx/report/) page.

**Before**
```text
... and exporting those `il` LaTeX for ...
```

**After**
```text
... and exporting those `in` LaTeX for ...
```

In `index.md`, I fixed a broken link and another typo.

**Before**
```text
[Weighted Sum](https://amenra.github.io/ranx/fusion/`#wighted-sum`)
```

**After**
```text
[Weighted Sum](https://amenra.github.io/ranx/fusion/`#weighted-sum`)
```

And finally, I found another typo in `fusion.md`

**Before**
```text
### LogN_ISR
Computes `Log_ISR` as proposed by [Mourão et al.](https://www.sciencedirect.com/science/article/abs/pii/S0895611114000664).
```

**After**
```text
### LogN_ISR
Computes `LogN_ISR` as proposed by [Mourão et al.](https://www.sciencedirect.com/science/article/abs/pii/S0895611114000664).
```

Thank you for making `ranx`, I really love this project and I am happy to contribute.
