### PR TITLE
Include Tukey’s HSD test in statistical tests documentation

### DIFF
--- a/docs/stat_tests.md
+++ b/docs/stat_tests.md
@@ -4,9 +4,12 @@
 
 - [Fisher's Randomization Test](https://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/fishrand.htm)
 - [Two-sided Paired Student's t-Test](https://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/t_test.htm)
+- [Tukey’s HSD test](https://www.itl.nist.gov/div898/handbook/prc/section4/prc471.htm)
 
 Please, refer to [Smucker et al.](https://dl.acm.org/doi/10.1145/1321440.1321528) for additional information on statistical tests for Information Retrieval.
 
 To use the [Fisher's Randomization Test](https://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/fishrand.htm), pass `stat_test="fisher"` to [compare](https://amenra.github.io/ranx/compare).
 
 To use the [Two-sided Paired Student's t-Test](https://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/t_test.htm), pass `stat_test="student"` to [compare](https://amenra.github.io/ranx/compare).
+
+To use the [Tukey’s HSD test](https://www.itl.nist.gov/div898/handbook/prc/section4/prc471.htm), pass `stat_test="Tukey"` to [compare](https://amenra.github.io/ranx/compare).


### PR DESCRIPTION
Hi,

I noticed that Tukey’s HSD test is not mentioned in the [statistical tests page](https://amenra.github.io/ranx/stat_tests/). I fixed that in this PR.