### PR TITLE
Fix Python 3.12+ SyntaxWarning and pandas 3.0 compatibility

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -3,4 +3,5 @@ extend-ignore-identifiers-re = [
     ".*Hsi",
     "relevants",
     "Comput",
+    "ttest.*",
 ]

--- a/ranx/data_structures/qrels.py
+++ b/ranx/data_structures/qrels.py
@@ -291,12 +291,12 @@ class Qrels(object):
         Returns:
             Qrels: ranx.Qrels
         """
-        assert (
-            df[q_id_col].dtype == "O"
-        ), "DataFrame Query IDs column dtype must be `object` (string)"
-        assert (
-            df[doc_id_col].dtype == "O"
-        ), "DataFrame Document IDs column dtype must be `object` (string)"
+        assert pd.api.types.is_string_dtype(
+            df[q_id_col]
+        ), "DataFrame Query IDs column dtype must be string"
+        assert pd.api.types.is_string_dtype(
+            df[doc_id_col]
+        ), "DataFrame Document IDs column dtype must be string"
         assert (
             df[score_col].dtype == np.int64
         ), "DataFrame scores column dtype must be `int`"

--- a/ranx/data_structures/report.py
+++ b/ranx/data_structures/report.py
@@ -199,21 +199,21 @@ class Report(object):
 
         table_prefix = (
             "% To change the table size, act on the resizebox argument `0.8`.\n"
-            + """\\begin{table*}[ht]\n\centering\n\caption{\nOverall effectiveness of the models.\nThe best results are highlighted in boldface.\nSuperscripts denote significant differences in """
+            + "\\begin{table*}[ht]\n\\centering\n\\caption{\nOverall effectiveness of the models.\nThe best results are highlighted in boldface.\nSuperscripts denote significant differences in "
             + self.get_stat_test_label(self.stat_test)
-            + """ with $p \le """
+            + " with $p \\le "
             + str(self.max_p)
             + "$.\n}\n\\resizebox{0.8\\textwidth}{!}{"
             + "\n\\begin{tabular}{c|l"
             + "|c" * len(self.metrics)
             + "}"
             + "\n\\toprule"
-            + "\n\\textbf{\#}"
+            + "\n\\textbf{\\#}"
             + "\n& \\textbf{Model}"
             + "".join(
                 [f"\n& \\textbf{{{self.get_metric_label(m)}}}" for m in self.metrics]
             )
-            + " \\\\ \n\midrule"
+            + " \\\\ \n\\midrule"
         )
 
         table_content = []
@@ -243,7 +243,7 @@ class Report(object):
         )
 
         table_suffix = (
-            "\\bottomrule\n\end{tabular}\n}\n\label{tab:results}\n\end{table*}"
+            "\\bottomrule\n\\end{tabular}\n}\n\\label{tab:results}\n\\end{table*}"
         )
 
         return (

--- a/ranx/data_structures/run.py
+++ b/ranx/data_structures/run.py
@@ -310,12 +310,12 @@ class Run(object):
         Returns:
             Run: ranx.Run
         """
-        assert (
-            df[q_id_col].dtype == "O"
-        ), "DataFrame Query IDs column dtype must be `object` (string)"
-        assert (
-            df[doc_id_col].dtype == "O"
-        ), "DataFrame Document IDs column dtype must be `object` (string)"
+        assert pd.api.types.is_string_dtype(
+            df[q_id_col]
+        ), "DataFrame Query IDs column dtype must be string"
+        assert pd.api.types.is_string_dtype(
+            df[doc_id_col]
+        ), "DataFrame Document IDs column dtype must be string"
         assert (
             df[score_col].dtype == np.float64
         ), "DataFrame scores column dtype must be `float`"


### PR DESCRIPTION
## Summary

Fixes two issues encountered when using ranx with Python 3.12+ and pandas 3.0:

- **`SyntaxWarning: invalid escape sequence`** — LaTeX strings in `report.py` used unescaped backslashes (e.g. `\centering`, `\le`, `\midrule`, `\end`, `\label`) which Python 3.12+ warns about and future versions will make a `SyntaxError`.

- **`AssertionError: DataFrame Query IDs column dtype must be 'object' (string)`** — `qrels.py` and `run.py` checked `dtype == "O"` to validate string columns, but pandas 3.0 defaults to `StringDtype` instead of `object` for string columns. Replaced with `pd.api.types.is_string_dtype()` which handles both.

## Test plan

- [x] `pytest` — 124 passed, 0 failed (previously 6 failures from the dtype issue)
- [x] Verified no `SyntaxWarning` on Python 3.11, 3.12, and 3.13