### PR TITLE
Add optional CI preflight for the TREC test fixtures

### DIFF
--- a/.github/workflows/trec-preflight.yml
+++ b/.github/workflows/trec-preflight.yml
@@ -1,0 +1,21 @@
+name: TREC fixture preflight
+
+on:
+  pull_request:
+    paths:
+      - "tests/unit/ranx/test_data/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Preflight TREC test fixtures
+        uses: Madhvansh/Neural-E-Commerce-Search@6fefdad10b60e71eedfcedee1491d6e043ebe670 # v0.3.1
+        with:
+          qrels: tests/unit/ranx/test_data/qrels.trec
+          run: tests/unit/ranx/test_data/run.trec


### PR DESCRIPTION
ranx's TREC test fixtures (`tests/unit/ranx/test_data/qrels.trec` + `run.trec`) came back clean in a structural-validation survey of public IR evaluation artifacts I published recently: 0 errors, 0 warnings at commit 7363db0 ([report](https://madhvansh.github.io/Neural-E-Commerce-Search/validated-artifacts.html), row 2, with SHA-256 hashes and reproduction commands).

This PR adds a small optional workflow that re-runs that structural preflight only when files under `tests/unit/ranx/test_data/` change (plus manual dispatch), so future fixture edits keep the same guarantees. The action is pinned by full commit SHA, needs nothing beyond the runner's Python 3, and adds no cost to normal PRs.

Disclosure: I maintain the validator. If this isn't something you want in CI, feel free to close — no hard feelings either way.